### PR TITLE
feat: add vocab list csv generator

### DIFF
--- a/src/app/[[...params]]/PDFLexicon.js
+++ b/src/app/[[...params]]/PDFLexicon.js
@@ -350,16 +350,21 @@ export default function PDFLexicon({ frequency, data }) {
 
   // return (<iframe title="preview" width="100%" height="500" src={URL.createObjectURL(blob)} ></iframe>);
   return (
-    <a
-      href={URL.createObjectURL(blob)}
-      download={
-        data[0].book + ' (<' + frequency + ') - Lexique du lecteur biblique.pdf'
-      }
-      className='text-decoration-none d-flex justify-content-end'
-    >
-      <Button variant='outline-dark' size='sm'>
-        <i className='bi bi-file-earmark-arrow-down' /> Télécharger en PDF
-      </Button>
-    </a>
+    <p className='d-flex justify-content-end'>
+      <a
+        href={URL.createObjectURL(blob)}
+        download={
+          data[0].book +
+          ' (<' +
+          frequency +
+          ') - Lexique du lecteur biblique.pdf'
+        }
+        className='text-decoration-none'
+      >
+        <Button variant='outline-dark' size='sm'>
+          <i className='bi bi-file-earmark-arrow-down' /> Télécharger en PDF
+        </Button>
+      </a>
+    </p>
   )
 }

--- a/src/app/[[...params]]/WordListGenerator.js
+++ b/src/app/[[...params]]/WordListGenerator.js
@@ -1,0 +1,160 @@
+import React from 'react'
+import { Button, Form } from 'react-bootstrap'
+import { getNonRareWordList, wordsToCsv } from '../word-list'
+
+const DEFAULT_RARE_WORDS_FREQUENCY = 10
+
+export default function WordListGenerator({ frequency, lexiconData }) {
+  const [interactionState, setInteractionState] = React.useState({
+    state: 'initial'
+  })
+
+  const handleFileChange = (event) => {
+    const file = event.target.files[0]
+
+    const reader = new FileReader()
+
+    reader.onload = (e) => {
+      const knownWordsListRaw = e.target.result
+      // FIXME: very naive csv parsing logic, need to use a library
+      const separator = knownWordsListRaw.includes(';') ? ';' : ','
+      const knownWordsList = knownWordsListRaw
+        .split('\n')
+        .flatMap((row) => row.split(separator)[0])
+
+      setInteractionState({
+        state: 'readyForDownload',
+        knownWordsList,
+        rareWordFrequency: DEFAULT_RARE_WORDS_FREQUENCY,
+        wordsToLearnList: getNonRareWordList(
+          knownWordsList,
+          lexiconData,
+          DEFAULT_RARE_WORDS_FREQUENCY
+        )
+      })
+    }
+
+    reader.onerror = (e) => {
+      console.error('Error reading file:', e)
+      setInteractionState({
+        state: 'uploadFailed'
+      })
+    }
+
+    // Read as text - change this based on your needs
+    reader.readAsText(file)
+  }
+
+  const handleChangeFrequency = (e) => {
+    setInteractionState({
+      ...interactionState,
+      rareWordFrequency: e.target.value,
+      wordsToLearnList: getNonRareWordList(
+        interactionState.knownWordsList,
+        lexiconData,
+        e.target.value
+      )
+    })
+  }
+
+  // TODO add feature documentation
+  // TODO filter words in knownWordList
+
+  return (
+    <div className='d-flex justify-content-end'>
+      {interactionState.state === 'initial' && (
+        <Button
+          variant='outline-dark'
+          size='sm'
+          onClick={() =>
+            setInteractionState({
+              state: 'proposingListUpload'
+            })
+          }
+        >
+          <i className='bi bi-list' /> Générer une liste de mots
+        </Button>
+      )}
+      {interactionState.state === 'proposingListUpload' && (
+        <>
+          <div>
+            <p>
+              Téléverser sa liste de mots déjà appris (format csv, une seule
+              colonne) :{' '}
+            </p>
+            <input id='fileInput' type='file' onChange={handleFileChange} />
+            <Button
+              variant='outline-dark'
+              size='sm'
+              onClick={() =>
+                setInteractionState({
+                  state: 'readyForDownload',
+                  knownWordsList: [],
+                  rareWordFrequency: DEFAULT_RARE_WORDS_FREQUENCY,
+                  wordsToLearnList: getNonRareWordList(
+                    [],
+                    lexiconData,
+                    DEFAULT_RARE_WORDS_FREQUENCY
+                  )
+                })
+              }
+            >
+              Je n'ai pas de liste de mots déjà appris
+            </Button>
+          </div>
+        </>
+      )}
+      {interactionState.state === 'uploadFailed' && (
+        <>
+          <span className='text-red'>Le fichier n'a pas pu être lu</span>
+          <input id='fileInput' type='file' onChange={handleFileChange} />
+        </>
+      )}
+      {interactionState.state === 'readyForDownload' && (
+        <div className='flex column'>
+          <div>
+            <Form.Label>Palier des mots rares</Form.Label>
+            <Form.Select
+              aria-label='Frequency selection'
+              value={interactionState.rareWordFrequency}
+              onChange={handleChangeFrequency}
+            >
+              {[
+                { text: 'Intermédiaire (<50×)', value: 50 },
+                { text: 'Connaisseur (<30×)', value: 30 },
+                { text: 'Expert (<10×)', value: 10 }
+              ]
+                .filter(({ value }) => value < frequency)
+                .map((option, id) => (
+                  <option value={option.value} key={id}>
+                    {option.text}
+                  </option>
+                ))}
+            </Form.Select>
+          </div>
+
+          <p>{interactionState.wordsToLearnList.length} mots à apprendre</p>
+          <a
+            href={URL.createObjectURL(
+              new Blob([wordsToCsv(interactionState.wordsToLearnList)], {
+                type: 'text/csv'
+              })
+            )}
+            download={
+              lexiconData[0].book +
+              ' (<' +
+              frequency +
+              ') - Liste de mots à apprendre.csv'
+            }
+            className='text-decoration-none'
+          >
+            <Button variant='outline-dark' size='sm'>
+              <i className='bi bi-list' /> Télécharger la liste des mots à
+              apprendre
+            </Button>
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/[[...params]]/page.js
+++ b/src/app/[[...params]]/page.js
@@ -20,6 +20,7 @@ import Lexicon from './Lexicon'
 import PDFLexicon from './PDFLexicon'
 // import LLBNav from './LLBNav'
 import * as ga from './ga.js'
+import WordListGenerator from './WordListGenerator'
 
 export default function Home({ params }) {
   const router = useRouter()
@@ -252,6 +253,11 @@ export default function Home({ params }) {
                   .
                 </p>
                 <PDFLexicon frequency={frequency} data={lexicon} />
+
+                <WordListGenerator
+                  frequency={frequency}
+                  lexiconData={lexicon}
+                />
               </Alert>
 
               <Alert variant='warning'>

--- a/src/app/util/array-unique.js
+++ b/src/app/util/array-unique.js
@@ -1,0 +1,3 @@
+export const arrayUniqueByKey = (arr, key) => [
+  ...new Map(arr.map((item) => [item[key], item])).values()
+]

--- a/src/app/word-list/index.js
+++ b/src/app/word-list/index.js
@@ -1,0 +1,37 @@
+import { arrayUniqueByKey } from '../util/array-unique'
+// TODO add tests
+
+export function getNonRareWordList(
+  knownWordsList,
+  lexiconData,
+  rareWordsFrequency
+) {
+  const uniqueNonRareWords = arrayUniqueByKey(
+    lexiconData
+      .filter((w) => w.freq > rareWordsFrequency)
+      .map((w) => ({
+        lex: w.lex,
+        strong: w.strong,
+        gloss: w.gloss
+      })),
+    'strong'
+  )
+
+  return uniqueNonRareWords.filter(
+    // Note: this can most likely be optimised if needed
+    (word) => !isInCurrentWordList(knownWordsList, word.lex)
+  )
+}
+
+export function isInCurrentWordList(knownWordList, lexeme) {
+  const normalizedLexeme = lexeme.normalize('NFC')
+
+  return knownWordList.some((w) => {
+    const normalizedW = w.normalize('NFC')
+    return normalizedW.includes(normalizedLexeme)
+  })
+}
+
+export function wordsToCsv(words) {
+  return words.map((w) => `"${w.lex}";"${w.gloss}"`).join('\n')
+}


### PR DESCRIPTION
⚠️  2 caveats : 
- Cette PR est ouverte sur la branche proposant un formattage standard, et ce pour qu'elle puisse être revue en ne montrant que les changements de la feature
- Elle propose une fonctionnalité expérimentale, probablement non-mergeable en l'état

## Besoin et cas d'utilisation

J'utilise le LLB que je trouve excellent pour me fournir une aide de lecture ! Je génère d'habitude un lexique pour un livre entier que je souhaite lire (par exemple dans mon culte personnel), et pas forcément dans le cas de l'étude d'un passage particulier. Je sélectionne seulement les mots rares (<=10 fois) à cet effet : ce sont les mots que je ne prendrai probablement pas la peine d'apprendre, et qu'il est confortable de pouvoir consulter facilement grâce au lexique (que j'imprime) lorsque je lis un verset.

Par contre, en tant qu'étudiant du Grec, j'aimerais ajouter les mots plus communs à ma liste d'apprentissage de vocabulaire avant de lire le livre, pour faciliter la lecture et nourrir mon vocabulaire (j'utilise Anki pour cela).

Le cas d'utilisation est donc le suivant : pour un livre donné, j'aimerais obtenir :
- Le lexique "rare" (<= 10x) -> ✅  c'est ce que LLB propose, c'est top
- Le lexique à apprendre (les mots qui apparaissent >10x et que je ne connais pas encore) -> ❓ Pas encore disponible via le LLB

Précision importante : je ne veux ajouter à ma liste d'apprentissage **que les mots qui n'y sont pas déjà**.

Je suis conscient qu'il existe des produits commerciaux qui proposent cela, encore que surtout en anglais. Je vois un grand intérêt à rendre cette fonctionnalité la plus libre d'utilisation possible, et gratuitement.

## Description de la fonctionnalité expérimentale

Cette PR propose le "proof-of-concept" d'une fonctionnalité permettant à l'utilisateur de générer une liste CSV des mots à apprendre sur la base de sa sélection du lexique, excluant les mots qu'il juge rare.

Nouveau bouton:
<img width="1319" height="360" alt="image" src="https://github.com/user-attachments/assets/82885caa-4d25-4b7a-8a97-1c1ec4a82c31" />

On peut uploader une liste de vocabulaire en csv (dans la première colonne du CSV, les autres seront ignorées), ou bien ne pas proposer de liste existante :
<img width="1319" height="360" alt="image" src="https://github.com/user-attachments/assets/99f4eef9-27ac-44be-b1c2-6acd26d15d59" />

On peut ensuite choisir le palier de "rareté" des mots, ce qui affiche le nombre des mots qui seront inclus dans la liste de mots produite, et télécharger cette liste :
<img width="1319" height="360" alt="image" src="https://github.com/user-attachments/assets/de5719bf-5f93-4fb8-8142-77f195538dc1" />

Précisions : 
- La liste produite contient chaque mot une seule fois, dans l'ordre d'apparition dans le lexique
- Les mots de la liste entrante (mots déjà appris) et de la liste du lexique sont comparés via une "standardisation" des accents pour éviter les fausses différences. On regarde si le mot du lexique de LLB *est inclus* dans une entrée du CSV uploadé (voir `isInCurrentWordList`). Les tests manuels effectués sur un vocabulaire grec ont bien marché (je l'ai fait pour ma lecture l'évangile de Jean et je n'ai pas le souvenir d'avoir eu des doublons)


## Travail restant pour publier

Si cette fonctionnalité est acceptée, il faudra discuter des/travailler sur les points suivants avant de pouvoir la publier :
- Présentation graphique/UX
- Amélioration de la logique de parsing du fichier uploadé (utiliser une librairie pour parser le CSV, éventuellement accepter d'autres formats, ...)
- Tester avec le vocabulaire hébreu (les tests de comparaison ont été faits seulement avec une liste de vocabulaire grec)
- Tests automatisés de la logique de parsing et de comparaison qui pourra être amenée à évoluer/être débuggées
- Edge cases à identifier

## Améliorations possibles

- Prendre en compte le vocabulaire connu aussi dans la production du lexique et du pdf. Par exemple, je pourrais connaître un mot "rare" qui apparaît <=10x dans le NT, et donc vouloir l'exclure du lexique/pdf car il est redondant pour moi
- Éventuellement, permettre de manipuler la liste des mots connus sur le LLB lui-même (consulter sa liste de vocabulaire, ajouter, enlever à la main ou via la liste du lexique, listes différenciées hébreu/grec)
- Checkbox pour exclure les noms propres (qui sont souvent transparents à la lecture) -> cela vaut également pour le lexique lui-même
- Inclure à la liste d'apprentissage les mots rares dans le NT **mais comparativement fréquents dans le livre**. Par exemple, si un mot est seulement présent 10x dans le NT, mais qu'il apparaît les 10x dans ce livre, c'est sans doute un mot typique de l'auteur qu'il est utile de mémoriser

