### PR TITLE
fix: word count

### DIFF
--- a/src/app/[[...params]]/page.js
+++ b/src/app/[[...params]]/page.js
@@ -20,6 +20,7 @@ import Lexicon from './Lexicon'
 import PDFLexicon from './PDFLexicon'
 // import LLBNav from './LLBNav'
 import * as ga from './ga.js'
+import { arrayUniqueByKey } from '../util/array-unique'
 
 export default function Home({ params }) {
   const router = useRouter()
@@ -241,7 +242,8 @@ export default function Home({ params }) {
               <Alert variant='light'>
                 <Alert.Heading>📌 Lexique créé!</Alert.Heading>
                 <p>
-                  <b>{lexicon.length}</b> des mots de{' '}
+                  <b>{arrayUniqueByKey(lexicon, 'strong').length}</b> des mots
+                  de{' '}
                   <b>
                     {book} {chapters}
                   </b>{' '}

--- a/src/app/util/array-unique.js
+++ b/src/app/util/array-unique.js
@@ -1,0 +1,3 @@
+export const arrayUniqueByKey = (arr, key) => [
+  ...new Map(arr.map((item) => [item[key], item])).values(),
+];


### PR DESCRIPTION
⚠️  PR ouverte sur la branche `build/add-formatter` car ces changements de formats sont requis pour le travail ajouté ici. Cette PR contient seulement les changements spécifiques au fix.

## Description du fix

Lors de l'affichage du lexique, le nombre de mots indiqué correspond au nombres de ligne du lexique. Il ne s'agit donc pas du nombre de mots uniques, comme la phrase semble le suggérer.

En tant qu'utilisateur, il me paraît plus logique et utile de connaître le nombre de mots *uniques* présents dans la section (inférieur voir très inférieur au nombre de lignes du lexique).

Si ce deuxième comportement est jugé plus utile, cette PR propose un fix pour afficher le nombre de mots *uniques* de la section sélectionnée. Voir un comparatif pour l'Ev. Jean avec les mots apparaissant <70x

Actuel :
<img width="1319" height="360" alt="image" src="https://github.com/user-attachments/assets/b4980c66-4011-4351-bca6-a5cdb573beff" />

Avec le fix:
<img width="1319" height="360" alt="image" src="https://github.com/user-attachments/assets/dc161d0c-a7ed-4990-866b-a9e092e307b2" />
